### PR TITLE
Configure the width of the spectrogram area using css variable

### DIFF
--- a/g-spectrogram.html
+++ b/g-spectrogram.html
@@ -2,18 +2,15 @@
 
 <polymer-element name="g-spectrogram" attributes="log speed fftsize min_scale color smoother">
   <template>
-  <style>
-    canvas {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-    }
-    g-spectrogram-controls {
-      position: absolute;
-    }
-  </style>
+    <style>
+      canvas {
+        position: relative;
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
     <canvas id="canvas"></canvas>
-    <canvas id="labels"></canvas>
   </template>
   <script src="g-spectrogram.js"></script>
 </polymer-element>

--- a/g-spectrogram.js
+++ b/g-spectrogram.js
@@ -4,7 +4,7 @@ Polymer('g-spectrogram', {
   // Speed of the visualization
   speed: 2,
   // FFT bin size,
-  fftsize: 2048*8,   // TODO - ADJUST WINDOW with factor
+  fftsize: 2048*8,   // fft window size (*2, *4, *8,...)
   // color scale controls
   min_rescale: 50,  // [1-255]
   color: true,   // true/false
@@ -41,20 +41,17 @@ Polymer('g-spectrogram', {
   },
 
   render: function() {
-    //console.log('Render');
-    this.width = window.innerWidth;
+    this.width = window.innerWidth / 2;
     this.height = window.innerHeight;
 
     var didResize = false;
     // Ensure dimensions are accurate.
     if (this.$.canvas.width != this.width) {
       this.$.canvas.width = this.width;
-      this.$.labels.width = this.width;
       didResize = true;
     }
     if (this.$.canvas.height != this.height) {
       this.$.canvas.height = this.height;
-      this.$.labels.height = this.height;
       didResize = true;
     }
 
@@ -97,7 +94,6 @@ Polymer('g-spectrogram', {
     // Copy the current canvas onto the temp canvas.
     this.tempCanvas.width = this.width;
     this.tempCanvas.height = this.height;
-    //console.log(this.$.canvas.height, this.tempCanvas.height);
     var tempCtx = this.tempCanvas.getContext('2d');
     tempCtx.drawImage(this.$.canvas, 0, 0, this.width, this.height);
 

--- a/g-spectrogram.js
+++ b/g-spectrogram.js
@@ -41,7 +41,10 @@ Polymer('g-spectrogram', {
   },
 
   render: function() {
-    this.width = window.innerWidth / 2;
+    const styles = getComputedStyle(document.documentElement);
+    const spectroWidth = styles.getPropertyValue('--spectro-width');
+
+    this.width = window.innerWidth * spectroWidth / 100;
     this.height = window.innerHeight;
 
     var didResize = false;

--- a/index.html
+++ b/index.html
@@ -7,12 +7,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body>
-    <!-- <div id="spectro"> -->
+    <div id="spectro">
       <g-spectrogram controls labels log oscillator></g-spectrogram>
       <div id="instructions">
         <h2>Click to start.</h2>
       </div>
-    <!-- </div> -->
+    </div>
   <script src="./bower_components/d3.min.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,12 +7,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body>
-    <g-spectrogram controls labels log oscillator></g-spectrogram>
-
-    <div id="instructions">
-      <h2>Click to start.</h2>
-    </div>
-  <!-- TODO - add as bower component if loading from url not possible -->
+    <!-- <div id="spectro"> -->
+      <g-spectrogram controls labels log oscillator></g-spectrogram>
+      <div id="instructions">
+        <h2>Click to start.</h2>
+      </div>
+    <!-- </div> -->
   <script src="./bower_components/d3.min.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,34 +1,31 @@
 :root {
   --spectro-width: 50;
   --left-fade-width: 10;
-  --right-fade-width: 5;
+  --right-fade-width: 3;
 }
 
-* {
+body, html {
   margin: 0;
   padding: 0;
-}
-
-html {
-  height: 100%;
-}
-
-body {
-  min-height: 100%;
-  width: calc(var(--spectro-width) * var(--u,1%));
-  margin: 0 auto;
   background-color: #440154;
 }
 
-#instructions {
+
+body {
+  width: calc(var(--spectro-width) * var(--u,1%));
   margin: 0 auto;
-  padding-top: 100px;
+}
+
+#instructions {
+  position: absolute;
+  left: 200px;
+  top: 200px;
   width: 500px;
   font-size: 80%;
   color: lightgrey;
 }
 
-/* #spectro {
+#spectro {
   height: 100%;
 }
 
@@ -58,4 +55,4 @@ body {
                     #440154);
   width    : calc(var(--right-fade-width) * var(--u,1%));
   height   : 100%;
-} */
+}

--- a/style.css
+++ b/style.css
@@ -1,6 +1,22 @@
-body, html {
+:root {
+  --spectro-width: 50;
+  --left-fade-width: 10;
+  --right-fade-width: 5;
+}
+
+* {
   margin: 0;
   padding: 0;
+}
+
+html {
+  height: 100%;
+}
+
+body {
+  min-height: 100%;
+  width: calc(var(--spectro-width) * var(--u,1%));
+  margin: 0 auto;
   background-color: #440154;
 }
 
@@ -11,3 +27,35 @@ body, html {
   font-size: 80%;
   color: lightgrey;
 }
+
+/* #spectro {
+  height: 100%;
+}
+
+#spectro::after {
+    content  : "";
+    position : absolute;
+    z-index  : 1;
+    bottom   : 0;
+    left     : calc((100 - var(--spectro-width))/ 2 * var(--u,1%));
+    pointer-events   : none;
+    background-image : linear-gradient(to left,
+                      rgba(255,255,255, 0),
+                      #440154);
+    width    : calc(var(--left-fade-width) * var(--u,1%));
+    height   : 100%;
+}
+
+#spectro::before {
+  content  : "";
+  position : absolute;
+  z-index  : 1;
+  bottom   : 0;
+  left     : calc((100 - (100 - var(--spectro-width))/ 2 - var(--right-fade-width)) * var(--u,1%));
+  pointer-events   : none;
+  background-image : linear-gradient(to right,
+                    rgba(255,255,255, 0),
+                    #440154);
+  width    : calc(var(--right-fade-width) * var(--u,1%));
+  height   : 100%;
+} */


### PR DESCRIPTION
@JennaVergeynst, PR provides option of setting the used width by the spectrogram. See the `style.css` variable `  --spectro-width: 50;` which I set on 50 (as in 50%) by default.
